### PR TITLE
Indicate package group resolving error as such

### DIFF
--- a/pacman/relations.go
+++ b/pacman/relations.go
@@ -121,7 +121,7 @@ func resolvePackageGroup(groupName string) ([]string, error) {
 	cmd.Stderr = os.Stderr
 	out, err := cmd.Output()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Error resolving package group '%s': %s", groupName, err.Error())
 	}
 
 	return strings.Fields(string(out)), nil

--- a/pacman/relations.go
+++ b/pacman/relations.go
@@ -121,7 +121,7 @@ func resolvePackageGroup(groupName string) ([]string, error) {
 	cmd.Stderr = os.Stderr
 	out, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("Error resolving package group '%s': %s", groupName, err.Error())
+		return nil, fmt.Errorf("Error resolving package group %q: %s", groupName, err.Error())
 	}
 
 	return strings.Fields(string(out)), nil


### PR DESCRIPTION
I've run into this error multiple times and all it said was `cannot build hologram-3.0.4-1-any.pkg.tar.xz: Failed to write .PKGINFO: exit status 1`. Every time I needed quite a bit to figure out it was a package group resolving error.

This PR fixes the error message to make debugging hologram definitions easier.