### PR TITLE
support prerelease packages (alpha and beta)

### DIFF
--- a/debian/generator.go
+++ b/debian/generator.go
@@ -89,11 +89,21 @@ func (g *Generator) Validate() []error {
 }
 
 func fullVersionString(pkg *build.Package) string {
-	str := fmt.Sprintf("%s-%d", pkg.Version, pkg.Release)
+	var b strings.Builder
+
 	if pkg.Epoch > 0 {
-		str = fmt.Sprintf("%d:%s", pkg.Epoch, str)
+		fmt.Fprintf(&b, "%d:", pkg.Epoch)
 	}
-	return str
+
+	b.WriteString(pkg.Version)
+
+	if pkg.PrereleaseType != build.PrereleaseTypeNone {
+		fmt.Fprintf(&b, "~%s.%d", pkg.PrereleaseType.ToString(), pkg.PrereleaseNo)
+	}
+
+	fmt.Fprintf(&b, "-%d", pkg.Release)
+
+	return b.String()
 }
 
 type arArchiveEntry struct {

--- a/package.go
+++ b/package.go
@@ -48,6 +48,30 @@ const (
 	ArchitectureAArch64
 )
 
+//PrerelaseType is an enum that describes whether the package is an alpha, beta or final release.
+type PrereleaseType uint
+
+const (
+	// Final release
+	PrereleaseTypeNone PrereleaseType = iota
+	// Alpha
+	PrereleaseTypeAlpha
+	// Beta
+	PrereleaseTypeBeta
+)
+
+func (pt PrereleaseType) ToString() string {
+	switch pt {
+	case PrereleaseTypeNone:
+		return "none"
+	case PrereleaseTypeAlpha:
+		return "alpha"
+	case PrereleaseTypeBeta:
+		return "beta"
+	}
+	panic("unreachable")
+}
+
 //Package contains all information about a single package. This representation
 //will be passed into the generator backends.
 type Package struct {
@@ -55,6 +79,13 @@ type Package struct {
 	Name string
 	//Version is the version for the package contents.
 	Version string
+	//PrereleaseType specifies whether it's a an alpha, beta or a final release.
+	PrereleaseType PrereleaseType
+	//PrereleaseNo is a counter of prereleases of a given type.
+	//(PrereleaseType=alpha, PrereleaseNo=5) will append "alpha.5" to the
+	//package's version (with a separator appropriate for a given package
+	//format).
+	PrereleaseNo uint
 	//Release is a counter that can be increased when the same version of one
 	//package needs to be rebuilt. The default value shall be 1.
 	Release uint

--- a/pacman/generator.go
+++ b/pacman/generator.go
@@ -100,11 +100,21 @@ func (g *Generator) Build() ([]byte, error) {
 }
 
 func fullVersionString(pkg *build.Package) string {
-	str := fmt.Sprintf("%s-%d", pkg.Version, pkg.Release)
+	var b strings.Builder
+
 	if pkg.Epoch > 0 {
-		str = fmt.Sprintf("%d:%s", pkg.Epoch, str)
+		fmt.Fprintf(&b, "%d:", pkg.Epoch)
 	}
-	return str
+
+	b.WriteString(pkg.Version)
+
+	if pkg.PrereleaseType != build.PrereleaseTypeNone {
+		fmt.Fprintf(&b, "%s.%d", pkg.PrereleaseType.ToString(), pkg.PrereleaseNo)
+	}
+
+	fmt.Fprintf(&b, "-%d", pkg.Release)
+
+	return b.String()
 }
 
 func writePKGINFO(pkg *build.Package) error {

--- a/rpm/generator.go
+++ b/rpm/generator.go
@@ -22,6 +22,7 @@ package rpm
 
 import (
 	"fmt"
+	"strings"
 
 	build "github.com/holocm/libpackagebuild"
 )
@@ -81,10 +82,19 @@ func (g *Generator) RecommendedFileName() string {
 }
 
 func versionString(pkg *build.Package) string {
+	var b strings.Builder
+
 	if pkg.Epoch > 0 {
-		return fmt.Sprintf("%d:%s", pkg.Epoch, pkg.Version)
+		fmt.Fprintf(&b, "%d:", pkg.Epoch)
 	}
-	return pkg.Version
+
+	b.WriteString(pkg.Version)
+
+	if pkg.PrereleaseType != build.PrereleaseTypeNone {
+		fmt.Fprintf(&b, "~%s.%d", pkg.PrereleaseType.ToString(), pkg.PrereleaseNo)
+	}
+
+	return b.String()
 }
 
 func fullVersionString(pkg *build.Package) string {


### PR DESCRIPTION
The "PrereleaseType" and "PrereleaseNo" config values are incorporated
into version strings for different package formats in a way that makes
the package managers detect upgrades and downgrades correctly. Tested
with the sequence:

  1.0.0-alpha.1 < 1.0.0-alpha.3 < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0

For Debian and RPM the "prerelease" part of version is separated
from the main part with "~". It's an established convention on Debian.

Fedora has other recommendations, which, unfortunately, omit this
information from the version string. The Debian convention still works
with RPM and it's clearer to the end-user.

Pacman doesn't allow "~" in version strings. It allows "\_", but using
"\_" results in the "1.0.0-beta.11 -> 1.0.0" transition being
recognized as a downgrade. Dropping the separator altogether fixes the
issue.